### PR TITLE
closes#2569, changed fixed 4px to .38rem height.

### DIFF
--- a/src/components/ProgressBar/ProgressBar.vue
+++ b/src/components/ProgressBar/ProgressBar.vue
@@ -92,7 +92,7 @@ export default {
 			let height = 0
 			let borderRadius = 0
 			if (this.size === 'small') {
-				height = '4px'
+				height = '.38rem'
 				borderRadius = '2px'
 			} else if (this.size === 'medium') {
 				height = '6px'


### PR DESCRIPTION
The issue seems to be only in some browsers ( safari has it, firefox was fine) ,changed from fixed pixels to rem unit , displays the same accros the different browsers